### PR TITLE
Added tests for florence dataset add to collection screen

### DIFF
--- a/features/florence/datasets/dataset_collection.feature
+++ b/features/florence/datasets/dataset_collection.feature
@@ -1,0 +1,32 @@
+Feature: Add dataset to collection
+
+Users can add a dataset to a collection
+
+@florence @datasets @collection @happy_path @smoke
+Scenario: Add a dataset to a collection
+
+    Given I go to the dataset 'Add to collection' page
+    When I click on the select the edition dropdown
+    Then I see a list of available collections
+    When I select a collection
+    Then I see the correct release date and time for the collection
+    When I click 'Save and continue'
+    Then I have successfully added the dataset to a collection
+
+@florence @datasets @collection @happy_path @smoke
+Scenario: Add a version to a collection
+
+    Given I go to the version 'Add to collection' page
+    When I click on the select the edition dropdown
+    Then I see a list of available collections
+    When I select a collection
+    Then I see the correct release date and time for the collection
+    When I click 'Save and continue'
+    Then I have successfully added the dataset to a collection
+
+@florence @datasets @collection @unhappy_path @smoke
+Scenario: Error shown if no collection is selected
+
+    Given I go to the dataset 'Add to collection' page
+    When I click 'Save and continue'
+    Then I am shown the error 'You must select a collection'

--- a/features/florence/datasets/dataset_collection.feature
+++ b/features/florence/datasets/dataset_collection.feature
@@ -2,7 +2,7 @@ Feature: Add dataset to collection
 
 Users can add a dataset to a collection
 
-@florence @datasets @collection @happy_path @smoke
+@florence @datasets @create_collection @collection @happy_path @smoke
 Scenario: Add a dataset to a collection
 
     Given I go to the dataset 'Add to collection' page

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "nightwatch-allure-adapter": "^1.2.4",
     "nightwatch-cucumber": "^8.0.10",
     "phantomjs-prebuilt": "^2.1.15",
+    "request": "^2.83.0",
+    "request-promise": "^4.2.2",
     "selenium": "^2.20.0",
     "selenium-server": "^3.5.3",
     "selenium-webdriver": "^3.5.0",

--- a/page_objects/florence/addDatasetToCollectionPage.js
+++ b/page_objects/florence/addDatasetToCollectionPage.js
@@ -1,0 +1,45 @@
+module.exports = {
+    elements: {
+        heading: {
+            selector: 'h1',
+            locateStrategy: 'css selector'
+        },        
+        successHeading: {
+            selector: '//h1[contains(text(), "Success")]',
+            locateStrategy: 'xpath'
+        },
+        collectionDropdown: {
+            selector: '#collection',
+            locateStrategy: 'css selector'
+        },
+        collectionList: {
+            selector: '#collection option',
+            locateStrategy: 'css selector'
+        },
+        collection: {
+            selector: '#collection option:nth-child(2)',
+            locateStrategy: 'css selector'
+        },
+        releaseDate: {
+            selector: '.select-details__value',
+            locateStrategy: 'css selector'
+        },
+        releaseTime: {
+            selector: '.select-details span:last-child',
+            locateStrategy: 'css selector'
+        },
+        saveAndContinueButton: {
+            selector: '.btn',
+            locateStrategy: 'css selector'
+        },
+        errorMessage: {
+            selector: '.error-msg',
+            locateStrategy: 'css selector'
+        }
+    },
+    commands: [{
+        waitForLoad: function() {
+            return this.waitForElementVisible('@heading', 5000);
+        }
+    }]
+}

--- a/step_definitions/florence/dataset_collection.js
+++ b/step_definitions/florence/dataset_collection.js
@@ -1,0 +1,77 @@
+var {client} = require('nightwatch-cucumber');
+var {defineSupportCode} = require('cucumber');
+
+var addDatasetToCollectionPage = client.page.addDatasetToCollectionPage();
+var datasetID = datasetID || '931a8a2a-0dc8-42b6-a884-7b6054ed3b68';
+var edition = edition || 'Time-series';
+var version = version || '2' ;
+
+defineSupportCode(({Given, Then, When}) => {
+    /*
+    Add a dataset to a collection
+    */
+    Given(/I go to the dataset '([^"]*)' page/, (title) => {
+        return addDatasetToCollectionPage
+            .navigate(process.env.FLORENCE_URL + "/florence/datasets/" + datasetID + "/metadata/collection")     
+            .waitForLoad()
+            .expect.element('h1').text.to.equal(title);
+    });
+
+    /*
+    Add a version to a collection
+    */
+    Given(/I go to the version '([^"]*)' page/, (title) => {
+        return addDatasetToCollectionPage
+            .navigate(process.env.FLORENCE_URL + "/florence/datasets/" + datasetID + "/editions/" + edition + "/versions/" + version + "/collection")
+            .waitForLoad()
+            .expect.element('h1').text.to.equal(title);
+    });
+
+    /*
+    Steps below are reused
+    */
+    When(/^I click on the select the edition dropdown/, () => {
+        return addDatasetToCollectionPage
+            .click('@collectionDropdown')
+            .waitForElementVisible('@collectionList', 1000);
+    });
+
+    Then(/^I see a list of available collections/, () => {
+        return addDatasetToCollectionPage
+            .assert.elementPresent('@collection');
+    });
+
+    When(/^I select a collection/, () => {
+        return addDatasetToCollectionPage
+            .click('@collection');
+    });
+
+    Then(/^I see the correct release date and time for the collection/, () => {
+        return addDatasetToCollectionPage
+            .waitForElementVisible('@releaseDate', 1000)
+            .expect.element('@releaseDate').text.to.equal('Sunday, January 26th, 2025');
+        return addDatasetToCollectionPage
+            .expect.element('@releaseTime').text.to.equal('09:30:00');
+    });
+
+    When(/^I click 'Save and continue'/, () => {
+        return addDatasetToCollectionPage
+            .click('@saveAndContinueButton');
+    });
+
+    Then(/^I have successfully added the dataset to a collection/, () => {
+        return addDatasetToCollectionPage
+            .waitForElementVisible('@successHeading', 2000)
+            .expect.element('@heading').text.to.equal('Success');
+    });
+
+    /*
+    Error displayed if no collection is selected
+    */
+    Then(/^I am shown the error '([^"]*)'/, (error) => {
+        return addDatasetToCollectionPage
+            .waitForElementVisible('@errorMessage', 1000)
+            .expect.element('@errorMessage').text.to.equal(error);
+    });
+
+});

--- a/support/hooks.js
+++ b/support/hooks.js
@@ -291,7 +291,7 @@ defineSupportCode(({Before, After}) => {
         const usesCollection = (
             test.pickle.tags.some(tag => tag.name === "@florence")
             &&
-            test.pickle.tags.some(tag => tag.name === "@collection")
+            test.pickle.tags.some(tag => tag.name === "@create_collection")
         )
         if (usesCollection) {
             console.log('Logging into Zebedee to create a collection before test');

--- a/support/hooks.js
+++ b/support/hooks.js
@@ -5,7 +5,6 @@ var request = require("request-promise");
 
 var mongoURL = process.env.MONGODB_URL;
 var instance_id = process.env.INSTANCE_ID;
-var zebedeeURL = process.env.ZEBEDEE_URL + "/zebedee";
 var datasetCollection = mongoURL + "/datasets";
 var collections = [
     "contacts",
@@ -206,7 +205,7 @@ function restoreTestData() {
 }
 
 // Returns access token from Zebedee
-const requestAccessToken = login => request(
+const requestAccessToken = () => request(
     {
         "method":"POST", 
         "uri": process.env.FLORENCE_URL + "/zebedee/login",


### PR DESCRIPTION
### What

- Added acceptance tests for adding a dataset and version to a collection.
- Also tests unhappy path for validation.

### How to review

- Pull the same branch (`feature/florence-collection-tests`) on Florence
- In `dp-web-tests` repo run `npm install` (should install `request-promise`)
- To run the tests for just this set of tests use `$ ./node_modules/nightwatch/bin/nightwatch --env chrome --tag collection`

When running tests check logs for the successful creation of a new collection
Check tests pass
Check logs during teardown process that the collection is removed

### Who can review

Anyone.